### PR TITLE
Minor edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The solution utilises [Docker's VPNKit](https://github.com/moby/vpnkit) and [Jef
 
 ## Getting started
 
-Once you have pulled the repoistory into your WSL2 environment you have two options
+Once you have pulled the repoistory into your WSL2 environment (while not on VPN yet) you have two options
 
 ### *Option 1:*
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The solution utilises [Docker's VPNKit](https://github.com/moby/vpnkit) and [Jef
 
 ## Getting started
 
-Once you have pulled the repoistory into your WSL2 environment (while not on VPN yet) you have two options
+Once you have pulled the repoistory into your WSL2 environment you have two options
 
 ### *Option 1:*
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ This is the preferred option since it gurantees fresh copies of all the dependen
 ### *Option 2:*    
 If you prefer not to install Docker on your windows machine, you can run `sudo ./wsl-vpn-setup-no-docker.sh` which would download the required files.
 
+## Removal
+
+In case you want to remove or re-install the wsl-vpn files, you can run:
+
+1. `sudo ./wsl-vpn-unsetup.sh`
 
 <!-- ACKNOWLEDGEMENTS -->
 ## Acknowledgements

--- a/wsl-vpn-setup-no-docker.sh
+++ b/wsl-vpn-setup-no-docker.sh
@@ -1,6 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-if [ ${EUID:-$(id -u)} -ne 0 ]; then
+set -eu
+
+if [ ${EUID:-$(id -u)} -ne 0 ] || [ -z "${SUDO_USER-}" ]; then
     echo "You need to run this as sudo"
     exit 1
 fi
@@ -17,13 +19,14 @@ function write_to_file() {
 WSL_BIN=https://github.com/AmmarRahman/wsl-vpn/releases/latest/download/wslbin.tar.gz
 WIN_BIN=/mnt/c/bin
 
+apt update
 apt install -y socat
 
-wget $WSL_BIN -t -O wslbin.tar.gz
+wget "${WSL_BIN}" -t -O wslbin.tar.gz
 tar -xf wslbin.tar.gz .
-mkdir -p $WIN_BIN
-mv wsl-vpnkit.exe $WIN_BIN
-mv npiperelay.exe $WIN_BIN
+mkdir -p "${WIN_BIN}"
+mv wsl-vpnkit.exe "${WIN_BIN}"
+mv npiperelay.exe "${WIN_BIN}"
 mv vpnkit-tap-vsockd /sbin
 chown root:root /sbin/vpnkit-tap-vsockd
 rm wslbin.tar.gz 
@@ -36,9 +39,5 @@ chmod +x /etc/init.d/wsl-vpnkit
 touch /etc/sudoers.d/wsl-vpnkit
 write_to_file "${SUDO_USER} ALL=(ALL) NOPASSWD: /usr/sbin/service wsl-vpnkit *" /etc/sudoers.d/wsl-vpnkit
 
-
-
 write_to_file "service wsl-vpnkit start"  /etc/profile
 write_to_file "service wsl-vpnkit start"  /etc/zsh/zprofile
-
-

--- a/wsl-vpn-setup.sh
+++ b/wsl-vpn-setup.sh
@@ -1,46 +1,54 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-if [ ${EUID:-$(id -u)} -ne 0 ]; then
+set -eu
+
+if [ ${EUID:-$(id -u)} -ne 0 ] || [ -z "${SUDO_USER-}" ]; then
     echo "You need to run this as sudo"
     exit 1
 fi
 
 # This function check if the file exist then only append the line once
-
 function write_to_file() {
     if [ -e "$2" ]; then
         grep -qFs "$1" "$2" || echo "$1" | tee -a "$2"
-    fi 
+    fi
 }
 
 
-DOCKER_WSL="/mnt/c/Program\ Files/Docker/Docker/resources"
-apt install -y socat unzip p7zip genisoimage
+DOCKER_WSL="/mnt/c/Program Files/Docker/Docker/resources"
 
+for cmd in socat unzip isoinfo wget p7zip; do
+    if ! command -v "${cmd}" &> /dev/nul; then
+        # Warning: Specific to debian/ubuntu
+        apt update
+        apt install -y socat unzip p7zip genisoimage wget
+        break
+    fi
+done
 
-cp ./wsl_vpn_start.sh /usr/bin
+cp ./wsl_vpn_start.sh /usr/bin/
 chmod +x /usr/bin/wsl_vpn_start.sh
 cp ./wsl-vpnkit.service /etc/init.d/wsl-vpnkit
 chmod +x /etc/init.d/wsl-vpnkit
+chown root:root /etc/init.d/wsl-vpnkit
 
 # Dangerous stuff
 touch /etc/sudoers.d/wsl-vpnkit
 write_to_file "${SUDO_USER} ALL=(ALL) NOPASSWD: /usr/sbin/service wsl-vpnkit *" /etc/sudoers.d/wsl-vpnkit
+chown root:root /etc/sudoers.d/wsl-vpnkit
 
 cd ~
 mkdir -p /mnt/c/bin
-# Eval is used because I gave up on dealing with the space in the path
-eval cp "$DOCKER_WSL/vpnkit.exe" /mnt/c/bin/wsl-vpnkit.exe
+cp "${DOCKER_WSL}/vpnkit.exe" /mnt/c/bin/wsl-vpnkit.exe
 
-eval isoinfo -i "${DOCKER_WSL}/wsl/docker-for-wsl.iso" -R -x /containers/services/vpnkit-tap-vsockd/lower/sbin/vpnkit-tap-vsockd > ./vpnkit-tap-vsockd
-chmod +x vpnkit-tap-vsockd
+isoinfo -i "${DOCKER_WSL}/wsl/docker-for-wsl.iso" -R -x /containers/services/vpnkit-tap-vsockd/lower/sbin/vpnkit-tap-vsockd > ./vpnkit-tap-vsockd
 mv vpnkit-tap-vsockd /sbin/vpnkit-tap-vsockd
+chmod +x /sbin/vpnkit-tap-vsockd
 chown root:root /sbin/vpnkit-tap-vsockd
 
 wget https://github.com/jstarks/npiperelay/releases/download/v0.1.0/npiperelay_windows_amd64.zip
 unzip npiperelay_windows_amd64.zip npiperelay.exe
 rm npiperelay_windows_amd64.zip
-
 mv npiperelay.exe /mnt/c/bin/
 
 

--- a/wsl-vpn-unsetup.sh
+++ b/wsl-vpn-unsetup.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -eu
+
+if [ ${EUID:-$(id -u)} -ne 0 ]; then
+    echo "You need to run this as sudo"
+    exit 1
+fi
+
+function sed_file() {
+    if [ -e "${2}" ]; then
+        sed -i "${1}" "${2}"
+    fi 
+}
+
+function rm_if() {
+    if [ -e "${1}" ]; then
+        rm "${1}"
+    fi
+}
+
+service wsl-vpnkit stop || :
+
+rm_if /usr/bin/wsl_vpn_start.sh
+rm_if /etc/init.d/wsl-vpnkit
+rm_if /etc/sudoers.d/wsl-vpnkit
+rm_if /sbin/vpnkit-tap-vsockd
+
+rm_if /mnt/c/bin/npiperelay.exe
+rm_if /mnt/c/bin/wsl-vpnkit.exe
+rmdir /mnt/c/bin || :
+
+sed_file '/^service wsl-vpnkit start$/d' /etc/profile 
+sed_file '/^service wsl-vpnkit start$/d' /etc/zsh/zprofile
+
+echo "Removed!"

--- a/wsl-vpnkit.service
+++ b/wsl-vpnkit.service
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/usr/bin/env sh
 
 WSLVPNKIT_PATH="/usr/bin/wsl_vpn_start.sh"
 PID_PATH="/var/run/wsl-vpnkit.pid"

--- a/wsl_vpn_start.sh
+++ b/wsl_vpn_start.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
 WIN_BIN="/mnt/c/bin"
 SOCKET_PATH=/var/run/wsl-vpnkit.sock
 PIPE_PATH="//./pipe/wsl-vpnkit"


### PR DESCRIPTION
Just some minor cosmetic fixes

- `#!/usr/bin/env bash` is better than hard coding the specific bash path
- Paths in bash can handle spaces just fine if you do `x="foo bar"` without the `\` in it, now eval is no longer needed, as long as `"`s are used when you use the variable
- `"${VAR_NAME}"` helps bash out in some corner cases vs `"$VAR_NAME"`
- Added `set -eu` so that the script does not continue to run on error
- Added `apt update` cause I had never run it in my WSL (or it could also be out of date)
- Added a remove script to help out