### PR TITLE
Cleanup routing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 * text=auto
 
+*.env eol=lf
 *.sh eol=lf
 *.service eol=lf

--- a/README.md
+++ b/README.md
@@ -17,20 +17,26 @@ The solution utilises [Docker's VPNKit](https://github.com/moby/vpnkit) and [Jef
 3. Run the setup script:
     - *Option 1:* The preferred option since it gurantees fresh copies of all the dependencies to run the tunnel.
         1. Install Docker Desktop on your windows machine.
-        2. Run `sudo ./wsl-vpnkit-setup.sh` from within this folder
-    - *Option 2:* If you prefer not to install Docker on your windows machine, you can run `` which would download the required files.
+        2. Run `sudo ./wsl-vpnkit-setup.sh` from within this folder in WSL
+    - *Option 2:* If you prefer not to (or can't) install Docker on your Windows machine, you can have the script download the required files instead.
         1. `sudo ./wsl-vpnkit-setup.sh --no-docker`
+
+Once everything is working and you are satisfied, you can feel free to remove the cloned repository; all relavent files have been installed (However, you cannot delete `C:\bin\` in Windows)
 
 ## Removal
 
 In case you want to remove and/or re-install the wsl-vpn files, you can run:
 
-1. `sudo ./wsl-vpnkit-unsetup.sh`
+1. In the cloned repo, run:
+    - `sudo ./wsl-vpnkit-unsetup.sh`
 
-## Troubleshooting
+## FAQ
 
-1. `./wsl-vpnkit-setup.sh: line 64: WSL_DISTRO_NAME: unbound variable`
-    - If you decided to `su -` or `sudo su -` instead of following the instructions as stated (i.e. `sudo {command}`) then the environment variable `WSL_DISTRO_NAME` will not be set. An easy solution is to set it yourself: e.g. `declare -p WSL_DISTRO_NAME=Ubuntu-20.04` where `Ubuntu-20.04` is the name of the WSL image you are running.
+1. What if I have multiple WSLs?
+    - You only install WSL-VPN into one WSL2 distro. The rest of the distros will get working internet from the WSL-VPN distro.
+    - The only caveat is that you must start the WSL-VPN distro everytime you restart your computer or "shutdown" or "terminate" the WSL-VPN distro.
+    - Simply opening up a tab to the WSL-VPN distro starts and fixes all of the other WSL2 distros. You can close it as soon as you open it.
+    - If you need to script starting WSL-VPN: `/mnt/c/Windows/System32/wsl.exe -d {WSL-VPN distro name} --user root service wsl-vpnkit start`
 
 <!-- ACKNOWLEDGEMENTS -->
 ## Acknowledgements

--- a/README.md
+++ b/README.md
@@ -6,17 +6,20 @@ The solution utilises [Docker's VPNKit](https://github.com/moby/vpnkit) and [Jef
 
 ## Getting started
 
-Once you have pulled the repoistory into your WSL2 environment you have two options
-
-### *Option 1:*
-
-This is the preferred option since it gurantees fresh copies of all the dependencies to run the tunnel.
-1. Install Docker Desktop on your windows machine.
-2. run `sudo ./wsl-vpnkit-setup.sh` from within this folder
-
-
-### *Option 2:*
-If you prefer not to install Docker on your windows machine, you can run `sudo ./wsl-vpnkit-setup.sh --no-docker` which would download the required files.
+1. Clone the repo, in windows or WSL.
+    - If you are currently on VPN, you can only clone from WSL1 or Windows. It doesn't matter where you put the repo, as it can be removed when done.
+2. (Currently) if you are on VPN, you will have to install `socat` (and `unzip` and `isoinfo` for Option 1 below) before you can run the setup script.
+    - Easy option: Get off of VPN
+    - Or if you cannot (for example, always-on-VPN Corporate rules)
+        1. You can convert to image to WSL1: Windows: `wsl --set-version {WSL_NAME} 1`
+        2. Install these dependencies (e.g. `apt-get update; apt-get install socat unzip genisoinfo`)
+        3. Convert it back to WSL2: Windows: `wsl --set-version {WSL_NAME} 2`
+3. Run the setup script:
+    - *Option 1:* The preferred option since it gurantees fresh copies of all the dependencies to run the tunnel.
+        1. Install Docker Desktop on your windows machine.
+        2. Run `sudo ./wsl-vpnkit-setup.sh` from within this folder
+    - *Option 2:* If you prefer not to install Docker on your windows machine, you can run `` which would download the required files.
+        1. `sudo ./wsl-vpnkit-setup.sh --no-docker`
 
 ## Removal
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ In case you want to remove and/or re-install the wsl-vpn files, you can run:
 
 1. `sudo ./wsl-vpnkit-unsetup.sh`
 
+## Troubleshooting
+
+1. `./wsl-vpnkit-setup.sh: line 64: WSL_DISTRO_NAME: unbound variable`
+    - If you decided to `su -` or `sudo su -` instead of following the instructions as stated (i.e. `sudo {command}`) then the environment variable `WSL_DISTRO_NAME` will not be set. An easy solution is to set it yourself: e.g. `declare -p WSL_DISTRO_NAME=Ubuntu-20.04` where `Ubuntu-20.04` is the name of the WSL image you are running.
+
 <!-- ACKNOWLEDGEMENTS -->
 ## Acknowledgements
 * [wsl-vpnkit](https://github.com/sakai135/wsl-vpnkit)

--- a/common.env
+++ b/common.env
@@ -43,10 +43,16 @@ function rm_if()
   fi
 }
 
+function rmdir_if()
+{
+  if [ -d "${1}" ]; then
+    rmdir "${1}"
+  fi
+}
+
 function sed_file()
 {
   if [ -e "${2}" ]; then
     sed -i "${1}" "${2}"
   fi
 }
-

--- a/common.env
+++ b/common.env
@@ -1,3 +1,6 @@
+
+: ${no_docker=0}
+
 : ${WIN_BIN=/mnt/c/bin}
 : ${WSLBIN_URL=https://github.com/AmmarRahman/wsl-vpn/releases/latest/download/wslbin.tar.gz}
 : ${NPIPRELAY_URL=https://github.com/jstarks/npiperelay/releases/download/v0.1.0/npiperelay_windows_amd64.zip}

--- a/common.env
+++ b/common.env
@@ -1,5 +1,6 @@
 
 : ${no_docker=0}
+: ${no_start=0}
 
 : ${WIN_BIN=/mnt/c/bin}
 : ${WSLBIN_URL=https://github.com/AmmarRahman/wsl-vpn/releases/latest/download/wslbin.tar.gz}

--- a/wsl-vpnkit-setup.sh
+++ b/wsl-vpnkit-setup.sh
@@ -26,9 +26,11 @@ if [ ${EUID:-$(id -u)} -ne 0 ]; then
   exit 1
 fi
 
-# Need WSL_DISTRO_NAME, because _this_ wsl might not be the default
+# Need WSL_DISTRO_NAME, because sudo usually removes this variable
 if [ -z "${WSL_DISTRO_NAME:+set}" ]; then
-  eval "$(cat /proc/$(ppid $(ppid $$))/environ | tr "\0" "\n" | grep ^WSL_DISTRO_NAME=)"
+  # eval "$(cat /proc/$(ppid $(ppid $$))/environ | tr "\0" "\n" | grep ^WSL_DISTRO_NAME=)"
+  # Better way: https://github.com/microsoft/WSL/issues/4479#issuecomment-876698799
+  WSL_DISTRO_NAME="$(IFS='\'; x=($(wslpath -w /)); echo "${x[${#x[@]}-1]}")"
 fi
 
 # Determine dependencies
@@ -109,7 +111,6 @@ write_to_file "service wsl-vpnkit status > /dev/null || service wsl-vpnkit start
 echo "Setup complete!"
 
 if [ "${no_start}" = "0" ]; then
-  echo "Starting service..."
   service wsl-vpnkit status > /dev/null || service wsl-vpnkit start
-  echo "Should be working in 6 seconds"
+  echo "WSL VPNKit Service started. You may proceed to use the internet like normal"
 fi

--- a/wsl-vpnkit-setup.sh
+++ b/wsl-vpnkit-setup.sh
@@ -5,7 +5,6 @@ set -eu
 source common.env
 
 # Arg Parse
-no_docker=0
 additional_wsl=0
 while (( $# )); do
   case "${1}" in

--- a/wsl-vpnkit-setup.sh
+++ b/wsl-vpnkit-setup.sh
@@ -38,7 +38,7 @@ if [ "${additional_wsl}" = "0" ]; then
   deb_install=(socat)
   if [ "${no_docker}" = "0" ]; then
     dependencies+=(unzip isoinfo)
-    deb_install=(unzip genisoimage)
+    deb_install+=(unzip genisoimage)
   fi
 
   for cmd in "${dependencies[@]}"; do

--- a/wsl-vpnkit-setup.sh
+++ b/wsl-vpnkit-setup.sh
@@ -84,9 +84,6 @@ if [ "${no_docker}" = "0" ]; then
   chown root:root /usr/local/sbin/vpnkit-tap-vsockd
 
   # Install c:\bin\npiperelay.exe
-  # This doesn't require WSL internet to be working. Apparently calling powershell
-  # this way writes directly to this same directory
-  # /mnt/c/WINDOWS/system32/WindowsPowerShell/v1.0/powershell.exe -NoProfile -Command "Invoke-WebRequest -Uri https://github.com/jstarks/npiperelay/releases/download/v0.1.0/npiperelay_windows_amd64.zip -OutFile npiperelay_windows_amd64.zip"
   download "${NPIPRELAY_URL}" npiperelay_windows_amd64.zip
   unzip npiperelay_windows_amd64.zip npiperelay.exe
   rm npiperelay_windows_amd64.zip

--- a/wsl-vpnkit-setup.sh
+++ b/wsl-vpnkit-setup.sh
@@ -5,17 +5,16 @@ set -eu
 source common.env
 
 # Arg Parse
-additional_wsl=0
 while (( $# )); do
   case "${1}" in
     --no-docker)
       no_docker=1
       ;;
-    --additional-wsl)
-      additional_wsl=1
+    --no-start)
+      no_start=1
       ;;
     *)
-      echo "Usage: $0 [--no-docker|--additional-wsl]" >&2
+      echo "Usage: $0 [--no-docker|--no-start]" >&2
       exit 2
       ;;
   esac
@@ -32,99 +31,88 @@ if [ -z "${WSL_DISTRO_NAME:+set}" ]; then
   eval "$(cat /proc/$(ppid $(ppid $$))/environ | tr "\0" "\n" | grep ^WSL_DISTRO_NAME=)"
 fi
 
-if [ "${additional_wsl}" = "0" ]; then
-  # Determine dependencies
-  dependencies=(socat)
-  deb_install=(socat)
-  if [ "${no_docker}" = "0" ]; then
-    dependencies+=(unzip isoinfo)
-    deb_install+=(unzip genisoimage)
-  fi
+# Determine dependencies
+dependencies=(socat)
+deb_install=(socat)
+if [ "${no_docker}" = "0" ]; then
+  dependencies+=(unzip isoinfo)
+  deb_install+=(unzip genisoimage)
+fi
 
-  for cmd in "${dependencies[@]}"; do
-    if ! command -v "${cmd}" &> /dev/null; then
-      if command -v apt &> /dev/null; then
-        apt update
-        apt install -y "${deb_install[@]}"
-        break
-      # elif command -v yast2 &> /dev/null; then
-      #   ...
-      else
-        echo "Todo: program other package managers" &> /dev/null
-        exit 3
-      fi
+for cmd in "${dependencies[@]}"; do
+  if ! command -v "${cmd}" &> /dev/null; then
+    if command -v apt &> /dev/null; then
+      apt update
+      apt install -y "${deb_install[@]}"
+      break
+    # elif command -v yast2 &> /dev/null; then
+    #   ...
+    else
+      echo "Todo: program other package managers" &> /dev/null
+      exit 3
     fi
-  done
-
-  # Install /usr/local/bin/wsl-vpnkit-start.sh
-  cp ./wsl-vpnkit-start.sh /usr/local/bin/
-  chmod +x /usr/local/bin/wsl-vpnkit-start.sh
-  chown root:root /usr/local/bin/wsl-vpnkit-start.sh
-
-  # Install /etc/init.d/wsl-vpnkit
-  # WSL_DISTRO_NAME is not set when "service wsl-vpnkit start" is run, so put the value in the script
-  sed "s|%%WSL_DISTRO_NAME%%|${WSL_DISTRO_NAME}|; s|%%SYSTEM_ROOT%%|${SYSTEM_ROOT}|" ./wsl-vpnkit.service > /etc/init.d/wsl-vpnkit
-  chmod +x /etc/init.d/wsl-vpnkit
-  chown root:root /etc/init.d/wsl-vpnkit
-
-  # Install /etc/sudoers.d/wsl-vpnkit
-  if [ -n "${SUDO_USER:+set}" ]; then
-    touch /etc/sudoers.d/wsl-vpnkit
-    write_to_file "${SUDO_USER} ALL=(ALL) NOPASSWD: /usr/sbin/service wsl-vpnkit *" /etc/sudoers.d/wsl-vpnkit
-    chown root:root /etc/sudoers.d/wsl-vpnkit
   fi
+done
 
-  mkdir -p "${WIN_BIN}"
-  if [ "${no_docker}" = "0" ]; then
-    # Install c:\bin\wsl-vpnkit.exe
-    cp "${DOCKER_WSL}/vpnkit.exe" "${WIN_BIN}/wsl-vpnkit.exe"
+# Install /usr/local/bin/wsl-vpnkit-start.sh
+cp ./wsl-vpnkit-start.sh /usr/local/bin/
+chmod +x /usr/local/bin/wsl-vpnkit-start.sh
+chown root:root /usr/local/bin/wsl-vpnkit-start.sh
 
-    # Install /usr/local/sbin/vpnkit-tap-vsockd
-    isoinfo -i "${DOCKER_WSL}/wsl/docker-for-wsl.iso" -R -x /containers/services/vpnkit-tap-vsockd/lower/sbin/vpnkit-tap-vsockd > ./vpnkit-tap-vsockd
-    mv vpnkit-tap-vsockd /usr/local/sbin/vpnkit-tap-vsockd
-    chmod +x /usr/local/sbin/vpnkit-tap-vsockd
-    chown root:root /usr/local/sbin/vpnkit-tap-vsockd
+# Install /etc/init.d/wsl-vpnkit
+# WSL_DISTRO_NAME is not set when "service wsl-vpnkit start" is run, so put the value in the script
+sed "s|%%WSL_DISTRO_NAME%%|${WSL_DISTRO_NAME}|; s|%%SYSTEM_ROOT%%|${SYSTEM_ROOT}|" ./wsl-vpnkit.service > /etc/init.d/wsl-vpnkit
+chmod +x /etc/init.d/wsl-vpnkit
+chown root:root /etc/init.d/wsl-vpnkit
 
-    # Install c:\bin\npiperelay.exe
-    # This doesn't require WSL internet to be working. Apparently calling powershell
-    # this way writes directly to this same directory
-    # /mnt/c/WINDOWS/system32/WindowsPowerShell/v1.0/powershell.exe -NoProfile -Command "Invoke-WebRequest -Uri https://github.com/jstarks/npiperelay/releases/download/v0.1.0/npiperelay_windows_amd64.zip -OutFile npiperelay_windows_amd64.zip"
-    download "${NPIPRELAY_URL}" npiperelay_windows_amd64.zip
-    unzip npiperelay_windows_amd64.zip npiperelay.exe
-    rm npiperelay_windows_amd64.zip
-    mv npiperelay.exe "${WIN_BIN}"
-  else
-    download "${WSLBIN_URL}" wslbin.tar.gz
-    tar -xf wslbin.tar.gz .
-    mv wsl-vpnkit.exe "${WIN_BIN}"
-    mv npiperelay.exe "${WIN_BIN}"
-    mv vpnkit-tap-vsockd /usr/local/sbin/
-    chmod 755 /usr/local/sbin/vpnkit-tap-vsockd
-    chown root:root /usr/local/sbin/vpnkit-tap-vsockd
-    rm wslbin.tar.gz
-  fi
-
-  # /etc/profile.d/wsl-vpnkit.sh
-  echo "service wsl-vpnkit status > /dev/null || service wsl-vpnkit start" > /etc/profile.d/wsl-vpnkit.sh
-  chmod 644 /etc/profile.d/wsl-vpnkit.sh
-  chown root:root /etc/profile.d/wsl-vpnkit.sh
-  # Edit /etc/zsh/zprofile
-  write_to_file "service wsl-vpnkit status > /dev/null || service wsl-vpnkit start"  /etc/zsh/zprofile
+# Install /etc/sudoers.d/wsl-vpnkit
+if [ -n "${SUDO_USER:+set}" ]; then
+  touch /etc/sudoers.d/wsl-vpnkit
+  write_to_file "${SUDO_USER} ALL=(ALL) NOPASSWD: /usr/sbin/service wsl-vpnkit *" /etc/sudoers.d/wsl-vpnkit
+  chown root:root /etc/sudoers.d/wsl-vpnkit
 fi
 
-# /etc/wsl.conf
-if [ -e "/etc/wsl.conf" ]; then
-  cp /etc/wsl.conf /etc/.wsl.conf.orig
+mkdir -p "${WIN_BIN}"
+if [ "${no_docker}" = "0" ]; then
+  # Install c:\bin\wsl-vpnkit.exe
+  cp "${DOCKER_WSL}/vpnkit.exe" "${WIN_BIN}/wsl-vpnkit.exe"
+
+  # Install /usr/local/sbin/vpnkit-tap-vsockd
+  isoinfo -i "${DOCKER_WSL}/wsl/docker-for-wsl.iso" -R -x /containers/services/vpnkit-tap-vsockd/lower/sbin/vpnkit-tap-vsockd > ./vpnkit-tap-vsockd
+  mv vpnkit-tap-vsockd /usr/local/sbin/vpnkit-tap-vsockd
+  chmod +x /usr/local/sbin/vpnkit-tap-vsockd
+  chown root:root /usr/local/sbin/vpnkit-tap-vsockd
+
+  # Install c:\bin\npiperelay.exe
+  # This doesn't require WSL internet to be working. Apparently calling powershell
+  # this way writes directly to this same directory
+  # /mnt/c/WINDOWS/system32/WindowsPowerShell/v1.0/powershell.exe -NoProfile -Command "Invoke-WebRequest -Uri https://github.com/jstarks/npiperelay/releases/download/v0.1.0/npiperelay_windows_amd64.zip -OutFile npiperelay_windows_amd64.zip"
+  download "${NPIPRELAY_URL}" npiperelay_windows_amd64.zip
+  unzip npiperelay_windows_amd64.zip npiperelay.exe
+  rm npiperelay_windows_amd64.zip
+  mv npiperelay.exe "${WIN_BIN}"
 else
-  touch /etc/.wsl.conf.orig
+  download "${WSLBIN_URL}" wslbin.tar.gz
+  tar -xf wslbin.tar.gz .
+  mv wsl-vpnkit.exe "${WIN_BIN}"
+  mv npiperelay.exe "${WIN_BIN}"
+  mv vpnkit-tap-vsockd /usr/local/sbin/
+  chmod 755 /usr/local/sbin/vpnkit-tap-vsockd
+  chown root:root /usr/local/sbin/vpnkit-tap-vsockd
+  rm wslbin.tar.gz
 fi
 
+# /etc/profile.d/wsl-vpnkit.sh
+echo "service wsl-vpnkit status > /dev/null || service wsl-vpnkit start" > /etc/profile.d/wsl-vpnkit.sh
+chmod 644 /etc/profile.d/wsl-vpnkit.sh
+chown root:root /etc/profile.d/wsl-vpnkit.sh
+# Edit /etc/zsh/zprofile
+write_to_file "service wsl-vpnkit status > /dev/null || service wsl-vpnkit start"  /etc/zsh/zprofile
 
-# echo "Starting service..."
-# service wsl-vpnkit status > /dev/null || service wsl-vpnkit start
 echo "Setup complete!"
 
-echo "WSL ${WSL_DISTRO_NAME} must be restarted inorder for some of the changes to take affect"
-read -sn1 -p "Press any key to terminal ${WSL_DISTRO_NAME}"
-
-"${SYSTEM_ROOT}/system32/wsl.exe" -t "${WSL_DISTRO_NAME}"
+if [ "${no_start}" = "0" ]; then
+  echo "Starting service..."
+  service wsl-vpnkit status > /dev/null || service wsl-vpnkit start
+  echo "Should be working in 6 seconds"
+fi

--- a/wsl-vpnkit-unsetup.sh
+++ b/wsl-vpnkit-unsetup.sh
@@ -4,21 +4,6 @@ set -eu
 
 source common.env
 
-# Arg Parse
-# additional_wsl=0
-# while (( $# )); do
-#   case "${1}" in
-#     --additional-wsl)
-#       additional_wsl=1
-#       ;;
-#     *)
-#       echo "Usage: $0 [--additional-wsl]" >&2
-#       exit 2
-#       ;;
-#   esac
-#   shift 1
-# done
-
 if [ ${EUID:-$(id -u)} -ne 0 ]; then
   echo "You need to run this as root"
   exit 1
@@ -35,8 +20,7 @@ rm_if /mnt/c/bin/npiperelay.exe "${SYSTEM_ROOT}/system32/taskkill.exe" /im npipe
 rm_if /mnt/c/bin/wsl-vpnkit.exe "${SYSTEM_ROOT}/system32/taskkill.exe" /im wsl-vpnkit.exe
 rmdir /mnt/c/bin || :
 
-# sed_file '/service wsl-vpnkit start/d' /etc/profile
 rm_if /etc/profile.d/wsl-vpnkit.sh
 sed_file '/service wsl-vpnkit start/d' /etc/zsh/zprofile
 
-echo "Removed!" # Please restart this WSL to fully restore /etc/resolv.conf"
+echo "Removed!"

--- a/wsl-vpnkit-unsetup.sh
+++ b/wsl-vpnkit-unsetup.sh
@@ -16,11 +16,26 @@ rm_if /etc/init.d/wsl-vpnkit
 rm_if /etc/sudoers.d/wsl-vpnkit
 rm_if /usr/local/sbin/vpnkit-tap-vsockd
 
-rm_if /mnt/c/bin/npiperelay.exe "${SYSTEM_ROOT}/system32/taskkill.exe" /im npiperelay.exe
-rm_if /mnt/c/bin/wsl-vpnkit.exe "${SYSTEM_ROOT}/system32/taskkill.exe" /im wsl-vpnkit.exe
-rmdir /mnt/c/bin || :
+rm_if "${WIN_BIN}/npiperelay.exe" "${SYSTEM_ROOT}/system32/taskkill.exe" /im npiperelay.exe
+rm_if "${WIN_BIN}/wsl-vpnkit.exe" "${SYSTEM_ROOT}/system32/taskkill.exe" /im wsl-vpnkit.exe
+# Doesn't remove it if it's not empty
+rmdir_if "${WIN_BIN}" || :
 
 rm_if /etc/profile.d/wsl-vpnkit.sh
 sed_file '/service wsl-vpnkit start/d' /etc/zsh/zprofile
 
-echo "Removed!"
+# Left here for backwards compatibility reasons, we no longer edit /etc/wsl.conf
+# nor generate a /etc/.wsl.conf.orig
+if [ -e /etc/.wsl.conf.orig ]; then
+  if ! grep -q '^generateResolvConf = false' /etc/.wsl.conf.orig; then
+    sed_file '/^generateResolvConf = false.*/d' /etc/wsl.conf
+    # On the next restart of wsl, the symlink will be recreated
+    rm /etc/resolv.conf
+  fi
+  rm /etc/.wsl.conf.orig
+
+  echo "You'll need to restart this wsl image for changes to take affect"
+  echo "Run: /c/Windows/System32/wsl.exe -t {WSL_NAME}"
+fi
+
+echo "VPNKit for WSL has been Removed!"

--- a/wsl-vpnkit-unsetup.sh
+++ b/wsl-vpnkit-unsetup.sh
@@ -5,49 +5,38 @@ set -eu
 source common.env
 
 # Arg Parse
-additional_wsl=0
-while (( $# )); do
-  case "${1}" in
-    --additional-wsl)
-      additional_wsl=1
-      ;;
-    *)
-      echo "Usage: $0 [--additional-wsl]" >&2
-      exit 2
-      ;;
-  esac
-  shift 1
-done
+# additional_wsl=0
+# while (( $# )); do
+#   case "${1}" in
+#     --additional-wsl)
+#       additional_wsl=1
+#       ;;
+#     *)
+#       echo "Usage: $0 [--additional-wsl]" >&2
+#       exit 2
+#       ;;
+#   esac
+#   shift 1
+# done
 
 if [ ${EUID:-$(id -u)} -ne 0 ]; then
-  echo "You need to run this as roto"
+  echo "You need to run this as root"
   exit 1
 fi
 
-if [ "${additional_wsl}" = "0" ]; then
-  service wsl-vpnkit stop || :
+service wsl-vpnkit stop || :
 
-  rm_if /usr/local/bin/wsl-vpnkit-start.sh
-  rm_if /etc/init.d/wsl-vpnkit
-  rm_if /etc/sudoers.d/wsl-vpnkit
-  rm_if /usr/local/sbin/vpnkit-tap-vsockd
+rm_if /usr/local/bin/wsl-vpnkit-start.sh
+rm_if /etc/init.d/wsl-vpnkit
+rm_if /etc/sudoers.d/wsl-vpnkit
+rm_if /usr/local/sbin/vpnkit-tap-vsockd
 
-  rm_if /mnt/c/bin/npiperelay.exe "${SYSTEM_ROOT}/system32/taskkill.exe" /im npiperelay.exe
-  rm_if /mnt/c/bin/wsl-vpnkit.exe "${SYSTEM_ROOT}/system32/taskkill.exe" /im wsl-vpnkit.exe
-  rmdir /mnt/c/bin || :
+rm_if /mnt/c/bin/npiperelay.exe "${SYSTEM_ROOT}/system32/taskkill.exe" /im npiperelay.exe
+rm_if /mnt/c/bin/wsl-vpnkit.exe "${SYSTEM_ROOT}/system32/taskkill.exe" /im wsl-vpnkit.exe
+rmdir /mnt/c/bin || :
 
-  # sed_file '/service wsl-vpnkit start/d' /etc/profile
-  rm_if /etc/profile.d/wsl-vpnkit.sh
-  sed_file '/service wsl-vpnkit start/d' /etc/zsh/zprofile
-fi
+# sed_file '/service wsl-vpnkit start/d' /etc/profile
+rm_if /etc/profile.d/wsl-vpnkit.sh
+sed_file '/service wsl-vpnkit start/d' /etc/zsh/zprofile
 
-if [ -e /etc/.wsl.conf.orig ]; then
-  if ! grep -q '^generateResolvConf = false' /etc/.wsl.conf.orig; then
-    sed_file '/^generateResolvConf = false.*/d' /etc/wsl.conf
-    # On the next restart of wsl, the symlink will be recreated
-    rm /etc/resolv.conf
-  fi
-  rm /etc/.wsl.conf.orig
-fi
-
-echo "Removed! Please restart this WSL to fully restore /etc/resolv.conf"
+echo "Removed!" # Please restart this WSL to fully restore /etc/resolv.conf"


### PR DESCRIPTION
I saw you removed the VPNKit `resolv.conf` file here: d1a3e64d2855764caba01f5c79d4c74dc90d1f6e and was wondering what was going on.

# TL;DR

If we are going to use the default `resolv.conf` file, I think we need to do a little more work on the routing table.

## My mess of a travel to your conclusion

The default `resolv.conf` does not currently work with this version of the script.

As I understand it:

![image](https://user-images.githubusercontent.com/7596961/124827205-c1abd980-df43-11eb-895b-51c2fdbbeeb5.png)

(IPs are just as examples, they obviously vary)

## WSL1

In WSL1, the networks stack is one in the same with the host, so the `resolv.conf` points to the real DNS server, and WSL1 just accesses the DNS server. It doesn't really "cross" the dotted green line, cause it's already on the other side of it. Couldn't be simpler then that!

## WSL2 not on VPN

In WSL2, it has it's own network device and it's own virtual gateway adaptor (called `vEthernet (WSL)` on the Windows host) that it uses, all maintained invisibly by WSL2 magic. So the auto generated WSL2 `resolv.conf` points to the name server 172.16.48.1, and WSL2 traffic and DNS lookups is routed through 172.16.48.1

I think `ip route` typically looks like: 

```
default via 172.16.48.1 dev eth0
172.16.48.0/20 dev eth0 scope link  src 172.16.58.107
```

## WSL2 on VPN

### When not working

For some reason the green arrow just doesn't work.... The end

Changing the MTU around _never_ helped here.

Observation: From the Windows host, you can indeed: `nslookup www.google.com 172.16.48.1` and get a response. So on the Windows Host side, 172.16.48.1 is indeed working (more on this below). So the black arrow going to the real DNS still appears to work.

### With VPN kit

So my _limited_ understanding is since we can't go through the normal network based routing, we use a pipe and cross dotted green line, VPN Kit.

The routing table is _currently_ updated to look like:

```
default via 192.168.67.1 dev eth1
172.16.48.0/20 dev eth0 scope link  src 172.16.59.104
192.168.67.0/24 dev eth1 scope link  src 192.168.67.3
```

Now, if I try to access the DNS server 172.16.48.1, then the route will still go through eth0, not eth1. And since that green arrow still is not working. Thus DNS fails, and I need the `resolv.conf` and `wsl.conf` solution.

~I got to thinking "what if I deleted the second line of the routing table?" so I did, and it still failed. As I understand it, this should be using the orange arrow, and as I stated in the "when not working" section, this actually should be working. So I'm not certain at all why this is not working at all~ Oops, I typed in a number wrong

So I got to thinking "what if I deleted the second line of the routing table?" so I did, and it does indeed work, using the orange line. And it did indeed work. My first thought was "that's an extra hop for no reason" but now my second thought is that "well, that may work more universally in ways I can't currently fathom." So I think I agree with you, if we removed that eth0 line in the routing table.

# Bonuses

1. This will close issue sakai135/wsl-vpnkit#27 (it appears alpine is just ignoring /etc/resolv.conf and I don't understand why, but I also don't care 👍)
2. The `--additional-wsl` flag will completely go away, it is no longer needed
3. No need to restart WSL, that was only wo make `wsl.conf` take affect
4. Things are simplier. Horray!