### PR TITLE
More powershell

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ The solution utilises [Docker's VPNKit](https://github.com/moby/vpnkit) and [Jef
 
 1. Clone the repo, in windows or WSL.
     - If you are currently on VPN, you can only clone from WSL1 or Windows. It doesn't matter where you put the repo, as it can be removed when done.
-2. (Currently) if you are on VPN, you will have to install `socat` (and `unzip` and `isoinfo` for Option 1 below) before you can run the setup script.
+2. (Currently) if you are on VPN, you will have to install `socat` before you can run the setup script.
     - Easy option: Get off of VPN
     - Or if you cannot (for example, always-on-VPN Corporate rules)
         1. You can convert to image to WSL1: Windows: `wsl --set-version {WSL_NAME} 1`
-        2. Install these dependencies (e.g. `apt-get update; apt-get install socat unzip genisoinfo`)
+        2. Install these dependencies (e.g. `apt-get update; apt-get install socat`)
         3. Convert it back to WSL2: Windows: `wsl --set-version {WSL_NAME} 2`
 3. Run the setup script:
     - *Option 1:* The preferred option since it gurantees fresh copies of all the dependencies to run the tunnel.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # wsl-vpn
 
-This is a repository to script in the wrokaround for WSL2 connectivity over VPN based on [Keiichi Shimamura](https://github.com/sakai135/wsl-vpnkit) work.
+This is a repository to script in the wrokaround for WSL2 connectivity over VPN based on [Keiichi Shimamura](https://github.com/sakai135/wsl-vpnkit) work  on Ubuntu and Debian WSL Distros.
 
 The solution utilises [Docker's VPNKit](https://github.com/moby/vpnkit) and [Jeff Trotman's npiperelay](https://github.com/jstarks/npiperelay) to tunnel the connectivity
 
@@ -37,6 +37,9 @@ In case you want to remove and/or re-install the wsl-vpn files, you can run:
     - The only caveat is that you must start the WSL-VPN distro everytime you restart your computer or "shutdown" or "terminate" the WSL-VPN distro.
     - Simply opening up a tab to the WSL-VPN distro starts and fixes all of the other WSL2 distros. You can close it as soon as you open it.
     - If you need to script starting WSL-VPN: `/mnt/c/Windows/System32/wsl.exe -d {WSL-VPN distro name} --user root service wsl-vpnkit start`
+2. What if I want to use a distro other than Debian/Ubuntu?
+    - You can install a Debian or Ubuntu from the Windows store to run along side your other distros, and use the multiple WSLs support to get your particular distro to work.
+    - The only part that is specific to Debian and Ubuntu is the service script. You are free to wrap the script `/usr/local
 
 <!-- ACKNOWLEDGEMENTS -->
 ## Acknowledgements

--- a/common.env
+++ b/common.env
@@ -38,7 +38,7 @@ function extract_from_iso_ps()
   # $1 - iso name
   # $2 - filename path in iso
   # $3 - destination filename
-  
+
   # Extract-Archive extracts all files :(
   "${SYSTEM_ROOT}/system32/WindowsPowerShell/v1.0/powershell.exe" -NoProfile -Command '
     try
@@ -48,7 +48,7 @@ function extract_from_iso_ps()
     }
     finally
     {
-      Dismount-DiskImage -DevicePath $iso.DevicePath
+      $null = Dismount-DiskImage -DevicePath $iso.DevicePath
     }
     '
 }

--- a/common.env
+++ b/common.env
@@ -1,6 +1,7 @@
 
 : ${no_docker=0}
 : ${no_start=0}
+: ${on_vpn=0}
 
 : ${WIN_BIN=/mnt/c/bin}
 : ${WSLBIN_URL=https://github.com/AmmarRahman/wsl-vpn/releases/latest/download/wslbin.tar.gz}

--- a/common.env
+++ b/common.env
@@ -9,12 +9,47 @@
 : ${SYSTEM_ROOT=/mnt/c/Windows}
 
 # Download even if WSL vpn is not patched yet
-function download()
+function download_ps()
 {
   # $1 - Url
   # $2 - Download file (relative to cwd)
 
   "${SYSTEM_ROOT}/system32/WindowsPowerShell/v1.0/powershell.exe" -NoProfile -Command "Invoke-WebRequest -Uri \"$1\" -OutFile \"$2\""
+}
+
+function unzip_ps()
+{
+  # $1 - Archive name, current dir
+  # $2 - filename to extract
+
+  # Extract-Archive extracts all files :(
+  "${SYSTEM_ROOT}/system32/WindowsPowerShell/v1.0/powershell.exe" -NoProfile -Command '
+      Add-Type -AssemblyName System.IO.Compression.FileSystem
+      $zip = [System.IO.Compression.ZipFile]::OpenRead("$pwd\'"${1}"'")
+      $zip.entries | Where-Object { $_.FullName -eq "'"${2}"'" } | ForEach-Object {
+        [System.IO.Compression.ZipFileExtensions]::ExtractToFile($_, "$pwd\'"${2}"'", $true)
+      }
+    '
+}
+
+function extract_from_iso_ps()
+{
+  # $1 - iso name
+  # $2 - filename path in iso
+  # $3 - destination filename
+  
+  # Extract-Archive extracts all files :(
+  "${SYSTEM_ROOT}/system32/WindowsPowerShell/v1.0/powershell.exe" -NoProfile -Command '
+    try
+    {
+      $iso = Mount-DiskImage -ImagePath "'"$(wslpath -w "${1}")"'" -NoDriveLetter
+      Copy-Item "$($iso.DevicePath)\'"${2}"'" "'"${3}"'"
+    }
+    finally
+    {
+      Dismount-DiskImage -DevicePath $iso.DevicePath
+    }
+    '
 }
 
 # Get the parent pid, in a way that should work on any WSL distro

--- a/wsl-vpnkit-setup.sh
+++ b/wsl-vpnkit-setup.sh
@@ -36,10 +36,6 @@ fi
 # Determine dependencies
 dependencies=(socat)
 deb_install=(socat)
-if [ "${no_docker}" = "0" ]; then
-  dependencies+=(unzip isoinfo)
-  deb_install+=(unzip genisoimage)
-fi
 
 for cmd in "${dependencies[@]}"; do
   if ! command -v "${cmd}" &> /dev/null; then
@@ -80,18 +76,18 @@ if [ "${no_docker}" = "0" ]; then
   cp "${DOCKER_WSL}/vpnkit.exe" "${WIN_BIN}/wsl-vpnkit.exe"
 
   # Install /usr/local/sbin/vpnkit-tap-vsockd
-  isoinfo -i "${DOCKER_WSL}/wsl/docker-for-wsl.iso" -R -x /containers/services/vpnkit-tap-vsockd/lower/sbin/vpnkit-tap-vsockd > ./vpnkit-tap-vsockd
+  extract_from_iso_ps "${DOCKER_WSL}/wsl/docker-for-wsl.iso" containers/services/vpnkit-tap-vsockd/lower/sbin/vpnkit-tap-vsockd vpnkit-tap-vsockd
   mv vpnkit-tap-vsockd /usr/local/sbin/vpnkit-tap-vsockd
   chmod +x /usr/local/sbin/vpnkit-tap-vsockd
   chown root:root /usr/local/sbin/vpnkit-tap-vsockd
 
   # Install c:\bin\npiperelay.exe
-  download "${NPIPRELAY_URL}" npiperelay_windows_amd64.zip
-  unzip npiperelay_windows_amd64.zip npiperelay.exe
+  download_ps "${NPIPRELAY_URL}" npiperelay_windows_amd64.zip
+  unzip_ps npiperelay_windows_amd64.zip npiperelay.exe
   rm npiperelay_windows_amd64.zip
   mv npiperelay.exe "${WIN_BIN}"
 else
-  download "${WSLBIN_URL}" wslbin.tar.gz
+  download_ps "${WSLBIN_URL}" wslbin.tar.gz
   tar -xf wslbin.tar.gz .
   mv wsl-vpnkit.exe "${WIN_BIN}"
   mv npiperelay.exe "${WIN_BIN}"

--- a/wsl-vpnkit-start.sh
+++ b/wsl-vpnkit-start.sh
@@ -53,7 +53,7 @@ ipconfig()
   for route in ${OTHER_ROUTES[@]+"${OTHER_ROUTES[@]}"}; do
     ip route del ${route} # No quotes
   done
- 
+
   # plumb what will probably be eth1
   ip a add "${VPNKIT_LOWEST_IP}/255.255.255.0" dev "${TAP_NAME}"
   ip link set dev "${TAP_NAME}" up
@@ -65,12 +65,12 @@ ipconfig()
 close()
 {
   ip link set dev "${TAP_NAME}" down
-  
+
   # for some reason, you get this problem https://serverfault.com/a/978311/321910
   # Adding onlink works, and will be remove when WSL restarts, so it seems harmless
   if [[ ${IP_ROUTE} =~ onlink ]]; then
     ip route add ${IP_ROUTE} # No quotes
-  else 
+  else
     ip route add ${IP_ROUTE} onlink  # No quotes
   fi
   for route in ${OTHER_ROUTES[@]+"${OTHER_ROUTES[@]}"}; do
@@ -98,16 +98,6 @@ vpnkit &
 tap &
 
 # Wait for the ethernet device to be tapped
-# if command -f lshw &> /dev/null; then
-#   timeout 3 while : ; do
-#     if lshw -C network | grep "${TAP_NAME}"; then
-#       break
-#     fi
-#   done
-#   echo "Device "${TAP_NAME}" is taking too long to tap" >&2
-# else
-#   sleep 3
-# fi
 while [ ! -e "/sys/class/net/${TAP_NAME}" ]; do
   sleep 0.0001
 done

--- a/wsl-vpnkit-start.sh
+++ b/wsl-vpnkit-start.sh
@@ -18,7 +18,6 @@ WIN_PIPE_PATH="${PIPE_PATH//\//\\}"
 TAP_NAME=eth1
 
 IP_ROUTE=
-RESOLV_CONF=
 
 relay()
 {


### PR DESCRIPTION
Closes #3

- Removed `unzip` dependency, using Powershell.
- Removed `isoinfo` by using Powershell to temporarily mount the iso file, copy the files of interest out, and then unmounting the iso file. This is done without creating a drive letter, so the user will be none the wiser on what is going on in the background.
- Added a `--on-vpn` flag, that will download a statically compiled version of `socat` (Thanks @andrew-d). This binary works in both glibc *and* musl OSes like Alpine. 
- Since openrc varies from OS to OS, just added a little into the README to limit the scope of this to Debian and Ubuntu, rather than trying to support everything else (I abandoned my [more_oses](https://github.com/andyneff/wsl-vpn/tree/more_oses) branch)