### PR TITLE
Fix wsl clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ In case you want to remove and/or re-install the wsl-vpn files, you can run:
 2. What if I want to use a distro other than Debian/Ubuntu?
     - You can install a Debian or Ubuntu from the Windows store to run along side your other distros, and use the multiple WSLs support to get your particular distro to work.
     - The only part that is specific to Debian and Ubuntu is the service script. You are free to wrap the script `/usr/local
+3. What if I'm trying to expose a port from WSL2?
+    - Unforunately, this solution will not allow you to expose a port when on or off of VPN. If you need to expose a port when off of VPN, you'll need to run the `./wsl-vpnkit-unsetup.sh` script
+4. What about IPv6?
+    - On tested clients IPv6 actually works when on VPN without the need for WSL-VPN, and continues to work when WSL-VPN is fixing IPv4. Tested clients include:
+        - SonicWall NetExtender
+    - Exposing ports on IPv6 still works
+5. What if I started killing random parts of the WSL-VPN, and now nothing's working.
+    - Well, if the scripts are killed mid-script, they can't restore settings. But to fix this, you simply run: `wsl --shutdown` and everything will be restored.
+    - **Note**: This will restart _all_ WSLs. I.e. if you are running docker, it will be restarted.
 
 <!-- ACKNOWLEDGEMENTS -->
 ## Acknowledgements

--- a/common.env
+++ b/common.env
@@ -26,9 +26,10 @@ function unzip_ps()
   # Extract-Archive extracts all files :(
   "${SYSTEM_ROOT}/system32/WindowsPowerShell/v1.0/powershell.exe" -NoProfile -Command '
       Add-Type -AssemblyName System.IO.Compression.FileSystem
-      $zip = [System.IO.Compression.ZipFile]::OpenRead("$pwd\'"${1}"'")
+      $cwd = $pwd -replace "^Microsoft\.PowerShell\.Core\\FileSystem::"
+      $zip = [System.IO.Compression.ZipFile]::OpenRead("$cwd\'"${1}"'")
       $zip.entries | Where-Object { $_.FullName -eq "'"${2}"'" } | ForEach-Object {
-        [System.IO.Compression.ZipFileExtensions]::ExtractToFile($_, "$pwd\'"${2}"'", $true)
+        [System.IO.Compression.ZipFileExtensions]::ExtractToFile($_, "$cwd\'"${2}"'", $true)
       }
     '
 }

--- a/wsl-vpnkit-setup.sh
+++ b/wsl-vpnkit-setup.sh
@@ -17,7 +17,7 @@ while (( $# )); do
       on_vpn=1
       ;;
     *)
-      echo "Usage: $0 [--no-docker|--no-start]" >&2
+      echo "Usage: $0 [--no-docker|--no-start|--on-vpn]" >&2
       exit 2
       ;;
   esac
@@ -57,7 +57,8 @@ if ! command -v socat &> /dev/null; then
     install_socat
   else
     # This appears to work in alpine (musl) and ubuntu/fedora alike (glibc)
-    download_ps https://github.com/andrew-d/static-binaries/raw/8ae38c79510d072cdba0bf719ef4f16c052e2abc/binaries/linux/x86_64/socat /usr/local/bin/socat
+    download_ps https://github.com/andrew-d/static-binaries/raw/8ae38c79510d072cdba0bf719ef4f16c052e2abc/binaries/linux/x86_64/socat socat
+    mv socat /usr/local/bin/socat
     chmod 755 /usr/local/bin/socat
   fi
 fi
@@ -124,8 +125,8 @@ if [ "${no_start}" = "0" ]; then
   echo "WSL VPNKit Service started. You may proceed to use the internet like normal"
 
   if [ "${on_vpn}" = "1" ]; then
-    if [ -f "/usr/local/sbin/socat" ]; then
-      rm /usr/local/sbin/socat
+    if [ -f "/usr/local/bin/socat" ]; then
+      rm /usr/local/bin/socat
     fi
     if ! command -v socat &> /dev/null; then
       install_socat


### PR DESCRIPTION
It turns out that in Powershell, UNC paths are prepended with the useless string: `Microsoft.PowerShell.Core\FileSystem::`

```powershell
PS Microsoft.PowerShell.Core\FileSystem::\\wsl$\Ubuntu-20.04\home\me\src\wsl-vpn> echo $pwd

Path
----
Microsoft.PowerShell.Core\FileSystem::\\wsl$\Ubuntu-20.04\home\me\src\wsl-vpn
```

I forgot to test the unzip code for when I cloned it in a WSL location, but this patch should fix it now.

Also, updated the readme a little. Created sakai135/wsl-vpnkit#30 to try and answer the exposing ports use case. I feel like there may be a clever way to use docker's proxy system, but I can't figure it out.
