### PR TITLE
Reacquire proxy variables

### DIFF
--- a/common.env
+++ b/common.env
@@ -9,6 +9,20 @@
 : ${DOCKER_WSL=$(wslpath "C:\Program Files\Docker\Docker\resources")}
 : ${SYSTEM_ROOT=$(wslpath "C:\Windows")}
 
+# Check for environment variables that get lost with sudo, and copy them over
+source <("${SYSTEM_ROOT}/system32/wsl.exe" -e bash -c '
+  ev=($(compgen -A export | grep -E "${1}"))
+  if [ "${#ev[@]}" -gt 0 ]; then
+    declare -px "${ev[@]}"
+  fi
+' -- '^.*_[pP][rR][oO][xX][yY]$')
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^
+# If this needs to be expanded in the future, combine multiple patterns using |
+# E.g. '^foobar$|^foo_.*|.*_bar$' to include:
+# - "foobar" exactly
+# - anything that starts with "foo_"
+# - anything that ends in "_bar"
+
 # Download even if WSL vpn is not patched yet
 function download_ps()
 {


### PR DESCRIPTION
It turns out sudo in WSL loses environment variables and WSL has taken no care to preserve them (via the sudoers files). So as a work around, I devised of a technique to call wsl.exe from wsl, that then runs a normal bash session as not-root, and retrieves the environment variables that way.

http proxies are a common and standard enough thing that I felt this was justified to add to the setup scripts.